### PR TITLE
Add high-level KSeF batch workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,32 @@ await client.refreshAndStoreAccessToken(); // uses stored refresh token
 
 All hashes and payload sizes follow the RC5.7 base64/SHA-256 rules from `przeglad-kluczowych-zmian-ksef-api-2-0.md`.
 
+## High-level batch workflow
+
+For production batch submission, prefer `client.batch` over manually wiring archive metadata. The high-level workflow keeps persistence outside the SDK while owning the KSeF mechanics: tar.gz archive creation, invoice hash manifest, part splitting before encryption, AES encryption, part upload, polling, pagination, and result correlation by `invoiceHash`.
+
+```ts
+const prepared = await client.batch.prepare({
+  formCode,
+  invoices: [
+    { localId: 'invoice-123', fileName: 'invoice-123.xml', xml }
+  ]
+});
+
+const submitted = await client.batch.submit(accessToken, prepared, {
+  uploadConcurrency: 4
+});
+
+const finalStatus = await client.batch.waitForCompletion(accessToken, submitted.referenceNumber);
+const results = await client.batch.getMappedResults(
+  accessToken,
+  submitted.referenceNumber,
+  prepared.manifest
+);
+```
+
+The existing `createBatchSession(accessToken, formCode, buffer, ...)` helper remains available as a low-level/advanced API for callers that already own archive construction and part metadata.
+
 ## Permissions, tokens & sessions
 
 - `client.permissions`: covers `/permissions/**` (personal/entity grants, indirect/self-billing, EU administration, attachment consent) and the `/permissions/query/...` endpoints. Pagination matches the `pageOffset + pageSize` semantics described in `api-changelog.md` (RC5.x additions).

--- a/src/api2/batch.ts
+++ b/src/api2/batch.ts
@@ -16,7 +16,7 @@ import {
   BatchSessionUploader,
   SessionV2Service
 } from './services/sessions.js';
-import { buildManifest, buildTarGz } from './batch/archive.js';
+import { buildManifest, buildTarGz, estimateTarSize } from './batch/archive.js';
 import { encryptPart, sha256Base64 } from './batch/crypto.js';
 import { correlateBatchResults, mergeSessionInvoices } from './batch/results.js';
 import type {
@@ -29,6 +29,8 @@ import type {
   PreparedBatch,
   SubmittedBatch
 } from './batch/types.js';
+
+const DEFAULT_MAX_UNCOMPRESSED_ARCHIVE_SIZE_BYTES = 256 * 1024 * 1024;
 
 export { BatchFileBuilder } from './batch/file-builder.js';
 export { sha256Base64 } from './batch/crypto.js';
@@ -64,6 +66,8 @@ export class KsefBatchService {
   async prepare(options: BatchPrepareOptions): Promise<PreparedBatch> {
     const compressionType = options.compression ?? 'TarGz';
     const partSizeBytes = options.partSizeBytes ?? 100_000_000;
+    const maxUncompressedArchiveSizeBytes = options.maxUncompressedArchiveSizeBytes
+      ?? DEFAULT_MAX_UNCOMPRESSED_ARCHIVE_SIZE_BYTES;
 
     if (compressionType !== 'TarGz') {
       throw new Error('High-level batch.prepare currently supports TarGz only. Use low-level helpers for custom archives.');
@@ -74,11 +78,22 @@ export class KsefBatchService {
     if (!Number.isInteger(partSizeBytes) || partSizeBytes <= 0 || partSizeBytes > 100_000_000) {
       throw new Error('partSizeBytes must be an integer between 1 and 100000000');
     }
+    if (!Number.isInteger(maxUncompressedArchiveSizeBytes) || maxUncompressedArchiveSizeBytes <= 0) {
+      throw new Error('maxUncompressedArchiveSizeBytes must be a positive integer');
+    }
 
     const manifest = buildManifest(options.invoices);
     assertUnique(manifest.map((item) => item.localId), 'localId');
     assertUnique(manifest.map((item) => item.fileName), 'fileName');
     assertUnique(manifest.map((item) => item.invoiceHash), 'invoiceHash');
+
+    const uncompressedArchiveSize = estimateTarSize(manifest);
+    if (uncompressedArchiveSize > maxUncompressedArchiveSizeBytes) {
+      throw new Error(
+        `Batch uncompressed tar size ${uncompressedArchiveSize} exceeds buffered prepare limit of `
+        + `${maxUncompressedArchiveSizeBytes} bytes`
+      );
+    }
 
     const archive = buildTarGz(options.invoices);
     const rawParts = splitBuffer(archive, partSizeBytes);

--- a/src/api2/batch.ts
+++ b/src/api2/batch.ts
@@ -1,15 +1,120 @@
-import { createHash } from 'node:crypto';
-import type { BatchFileInfo, BatchFilePartInfo } from './types/common.js';
+import { createCipheriv, createHash } from 'node:crypto';
+import { gzipSync, constants as zlibConstants } from 'node:zlib';
+import type { HttpClient } from '@/utils/http.js';
+import type {
+  ApiV2Environment,
+  BatchFileInfo,
+  BatchFilePartInfo,
+  CompressionType,
+  FormCode,
+  PartUploadRequest
+} from './types/common.js';
+import type { SymmetricKeyMaterial } from './crypto/symmetric.js';
+import { SymmetricKeyManager } from './crypto/symmetric.js';
+import { SecurityService } from './security.js';
+import type {
+  SessionInvoicesResponse,
+  SessionInvoiceStatus,
+  SessionStatusResponse
+} from './types/session.js';
+import {
+  BatchSessionUploader,
+  type OpenBatchSessionOptions,
+  type OpenBatchSessionResult,
+  SessionV2Service
+} from './services/sessions.js';
 
 export interface BatchFileBuildResult {
   batchFile: BatchFileInfo;
   parts: Buffer[];
 }
 
+export interface BatchInvoiceInput {
+  localId: string;
+  fileName: string;
+  xml: string | Buffer;
+}
+
+export interface BatchManifestItem {
+  localId: string;
+  fileName: string;
+  invoiceHash: string;
+  invoiceSize: number;
+}
+
+export interface BatchPrepareOptions {
+  formCode: FormCode;
+  invoices: BatchInvoiceInput[];
+  /**
+   * High-level preparation currently builds tar.gz archives. The low-level
+   * helpers remain available for callers that already own another archive.
+   */
+  compression?: Extract<CompressionType, 'TarGz'>;
+  /** KSeF limit: parts are split before encryption and cannot exceed 100 MB. */
+  partSizeBytes?: number;
+  encryptionMaterial?: SymmetricKeyMaterial;
+}
+
+export interface PreparedBatch {
+  formCode: FormCode;
+  compressionType: Extract<CompressionType, 'TarGz'>;
+  batchFile: BatchFileInfo;
+  encryptedParts: Buffer[];
+  manifest: BatchManifestItem[];
+  encryptionMaterial: SymmetricKeyMaterial;
+  archiveSize: number;
+  archiveHash: string;
+  partSizeBytes: number;
+}
+
+export interface BatchSubmitOptions {
+  uploadConcurrency?: number;
+  closeSession?: boolean;
+  session?: Omit<OpenBatchSessionOptions, 'encryptionMaterial'>;
+}
+
+export interface SubmittedBatch {
+  referenceNumber: string;
+  session: OpenBatchSessionResult;
+  batchFile: BatchFileInfo;
+  manifest: BatchManifestItem[];
+  partUploadRequests: PartUploadRequest[];
+}
+
+export interface BatchWaitForCompletionOptions {
+  initialDelayMs?: number;
+  maxDelayMs?: number;
+  backoffFactor?: number;
+  timeoutMs?: number;
+  maxAttempts?: number;
+  isTerminal?: (status: SessionStatusResponse) => boolean;
+}
+
+export interface BatchListOptions {
+  pageSize?: number;
+}
+
+export interface BatchCorrelatedResult {
+  localId: string;
+  fileName: string;
+  invoiceHash: string;
+  invoiceSize: number;
+  sessionInvoice: SessionInvoiceStatus;
+}
+
+export interface BatchResultCorrelation {
+  matched: BatchCorrelatedResult[];
+  unmatchedSessionInvoices: SessionInvoiceStatus[];
+  missingManifestItems: BatchManifestItem[];
+}
+
 export class BatchFileBuilder {
   constructor(private readonly buffer: Buffer) {}
 
-  build(partSize = 5 * 1024 * 1024): BatchFileBuildResult {
+  build(
+    partSize = 5 * 1024 * 1024,
+    options: { compressionType?: CompressionType | null } = {}
+  ): BatchFileBuildResult {
     const parts: Buffer[] = [];
     const partInfos: BatchFilePartInfo[] = [];
 
@@ -27,6 +132,7 @@ export class BatchFileBuilder {
       batchFile: {
         fileSize: this.buffer.byteLength,
         fileHash: sha256Base64(this.buffer),
+        ...(options.compressionType ? { compressionType: options.compressionType } : {}),
         fileParts: partInfos
       },
       parts
@@ -38,4 +144,405 @@ export function sha256Base64(buffer: Buffer): string {
   const hash = createHash('sha256');
   hash.update(buffer);
   return hash.digest('base64');
+}
+
+export class KsefBatchService {
+  private readonly symmetricManager: SymmetricKeyManager;
+
+  constructor(
+    private readonly sessions: SessionV2Service,
+    private readonly batchUploader: BatchSessionUploader,
+    httpClient: HttpClient,
+    environment: ApiV2Environment,
+    securityService?: SecurityService
+  ) {
+    this.symmetricManager = new SymmetricKeyManager(
+      securityService ?? new SecurityService(httpClient, environment)
+    );
+  }
+
+  async prepare(options: BatchPrepareOptions): Promise<PreparedBatch> {
+    const compressionType = options.compression ?? 'TarGz';
+    const partSizeBytes = options.partSizeBytes ?? 100_000_000;
+
+    if (compressionType !== 'TarGz') {
+      throw new Error('High-level batch.prepare currently supports TarGz only. Use low-level helpers for custom archives.');
+    }
+    if (options.invoices.length === 0) {
+      throw new Error('Batch must contain at least one invoice');
+    }
+    if (!Number.isInteger(partSizeBytes) || partSizeBytes <= 0 || partSizeBytes > 100_000_000) {
+      throw new Error('partSizeBytes must be an integer between 1 and 100000000');
+    }
+
+    const manifest = buildManifest(options.invoices);
+    assertUnique(manifest.map((item) => item.localId), 'localId');
+    assertUnique(manifest.map((item) => item.fileName), 'fileName');
+    assertUnique(manifest.map((item) => item.invoiceHash), 'invoiceHash');
+
+    const archive = buildTarGz(options.invoices);
+    const rawParts = splitBuffer(archive, partSizeBytes);
+    if (rawParts.length > 50) {
+      throw new Error('Batch archive exceeds KSeF limit of 50 parts');
+    }
+
+    const encryptionMaterial = options.encryptionMaterial ?? await this.symmetricManager.createMaterial();
+    const encryptedParts = rawParts.map((part) => encryptPart(part, encryptionMaterial));
+    const fileParts = encryptedParts.map<BatchFilePartInfo>((part, index) => ({
+      ordinalNumber: index + 1,
+      fileSize: part.byteLength,
+      fileHash: sha256Base64(part)
+    }));
+    const archiveHash = sha256Base64(archive);
+    const batchFile: BatchFileInfo = {
+      fileSize: archive.byteLength,
+      fileHash: archiveHash,
+      compressionType,
+      fileParts
+    };
+
+    return {
+      formCode: options.formCode,
+      compressionType,
+      batchFile,
+      encryptedParts,
+      manifest,
+      encryptionMaterial,
+      archiveSize: archive.byteLength,
+      archiveHash,
+      partSizeBytes
+    };
+  }
+
+  async submit(
+    accessToken: string,
+    prepared: PreparedBatch,
+    options: BatchSubmitOptions = {}
+  ): Promise<SubmittedBatch> {
+    const session = await this.sessions.openBatchSession(
+      accessToken,
+      prepared.batchFile,
+      prepared.formCode,
+      {
+        ...options.session,
+        encryptionMaterial: prepared.encryptionMaterial
+      }
+    );
+
+    await this.uploadPreparedParts(
+      session.partUploadRequests,
+      prepared.encryptedParts,
+      options.uploadConcurrency ?? 4
+    );
+
+    if (options.closeSession !== false) {
+      await this.sessions.closeBatchSession(accessToken, session.referenceNumber);
+    }
+
+    return {
+      referenceNumber: session.referenceNumber,
+      session,
+      batchFile: prepared.batchFile,
+      manifest: prepared.manifest,
+      partUploadRequests: session.partUploadRequests
+    };
+  }
+
+  async waitForCompletion(
+    accessToken: string,
+    referenceNumber: string,
+    options: BatchWaitForCompletionOptions = {}
+  ): Promise<SessionStatusResponse> {
+    const isTerminal = options.isTerminal ?? ((status) => status.status.code >= 200);
+    const startedAt = Date.now();
+    const timeoutMs = options.timeoutMs ?? 15 * 60_000;
+    const maxAttempts = options.maxAttempts ?? Number.POSITIVE_INFINITY;
+    let delayMs = options.initialDelayMs ?? 5_000;
+    const maxDelayMs = options.maxDelayMs ?? 30_000;
+    const backoffFactor = options.backoffFactor ?? 1.5;
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      const status = await this.sessions.getSessionStatus(accessToken, referenceNumber);
+      if (isTerminal(status)) {
+        return status;
+      }
+      if (Date.now() - startedAt >= timeoutMs) {
+        throw new Error(`Batch session ${referenceNumber} did not complete within ${timeoutMs}ms`);
+      }
+      await sleep(delayMs);
+      delayMs = Math.min(maxDelayMs, Math.ceil(delayMs * backoffFactor));
+    }
+
+    throw new Error(`Batch session ${referenceNumber} did not complete within ${maxAttempts} attempts`);
+  }
+
+  async listAllInvoices(
+    accessToken: string,
+    referenceNumber: string,
+    options: BatchListOptions = {}
+  ): Promise<SessionInvoiceStatus[]> {
+    return await this.listAllSessionInvoices((continuationToken) =>
+      this.sessions.listSessionInvoices(
+        accessToken,
+        referenceNumber,
+        buildPaginationOptions(continuationToken, options.pageSize)
+      )
+    );
+  }
+
+  async listAllFailedInvoices(
+    accessToken: string,
+    referenceNumber: string,
+    options: BatchListOptions = {}
+  ): Promise<SessionInvoiceStatus[]> {
+    return await this.listAllSessionInvoices((continuationToken) =>
+      this.sessions.listFailedSessionInvoices(
+        accessToken,
+        referenceNumber,
+        buildPaginationOptions(continuationToken, options.pageSize)
+      )
+    );
+  }
+
+  correlateResults(
+    manifest: BatchManifestItem[],
+    sessionInvoices: SessionInvoiceStatus[]
+  ): BatchResultCorrelation {
+    const manifestByHash = new Map(manifest.map((item) => [item.invoiceHash, item]));
+    const matched: BatchCorrelatedResult[] = [];
+    const unmatchedSessionInvoices: SessionInvoiceStatus[] = [];
+    const matchedHashes = new Set<string>();
+
+    for (const sessionInvoice of sessionInvoices) {
+      const manifestItem = manifestByHash.get(sessionInvoice.invoiceHash);
+      if (!manifestItem) {
+        unmatchedSessionInvoices.push(sessionInvoice);
+        continue;
+      }
+      matched.push({
+        localId: manifestItem.localId,
+        fileName: manifestItem.fileName,
+        invoiceHash: manifestItem.invoiceHash,
+        invoiceSize: manifestItem.invoiceSize,
+        sessionInvoice
+      });
+      matchedHashes.add(manifestItem.invoiceHash);
+    }
+
+    return {
+      matched,
+      unmatchedSessionInvoices,
+      missingManifestItems: manifest.filter((item) => !matchedHashes.has(item.invoiceHash))
+    };
+  }
+
+  async getMappedResults(
+    accessToken: string,
+    referenceNumber: string,
+    manifest: BatchManifestItem[],
+    options: BatchListOptions = {}
+  ): Promise<BatchResultCorrelation> {
+    const [invoices, failedInvoices] = await Promise.all([
+      this.listAllInvoices(accessToken, referenceNumber, options),
+      this.listAllFailedInvoices(accessToken, referenceNumber, options)
+    ]);
+    return this.correlateResults(manifest, mergeSessionInvoices(invoices, failedInvoices));
+  }
+
+  private async uploadPreparedParts(
+    uploadRequests: PartUploadRequest[],
+    encryptedParts: Buffer[],
+    concurrency: number
+  ): Promise<void> {
+    if (!Number.isInteger(concurrency) || concurrency <= 0) {
+      throw new Error('uploadConcurrency must be a positive integer');
+    }
+
+    const requestsByOrdinal = new Map(uploadRequests.map((request) => [request.ordinalNumber, request]));
+    const items = encryptedParts.map((part, index) => {
+      const ordinalNumber = index + 1;
+      const request = requestsByOrdinal.get(ordinalNumber);
+      if (!request) {
+        throw new Error(`Missing upload request for batch part #${ordinalNumber}`);
+      }
+      return { request, part };
+    });
+
+    await runWithConcurrency(items, concurrency, async ({ request, part }) => {
+      await this.batchUploader.uploadPart(request, part);
+    });
+  }
+
+  private async listAllSessionInvoices(
+    fetchPage: (continuationToken?: string) => Promise<SessionInvoicesResponse>
+  ): Promise<SessionInvoiceStatus[]> {
+    const invoices: SessionInvoiceStatus[] = [];
+    const seenTokens = new Set<string>();
+    let continuationToken: string | undefined;
+
+    do {
+      const page = await fetchPage(continuationToken);
+      invoices.push(...page.invoices);
+      continuationToken = page.continuationToken ?? undefined;
+      if (continuationToken) {
+        if (seenTokens.has(continuationToken)) {
+          throw new Error('Session invoice pagination returned a repeated continuation token');
+        }
+        seenTokens.add(continuationToken);
+      }
+    } while (continuationToken);
+
+    return invoices;
+  }
+}
+
+function buildManifest(invoices: BatchInvoiceInput[]): BatchManifestItem[] {
+  return invoices.map((invoice) => {
+    const invoiceBuffer = toBuffer(invoice.xml);
+    return {
+      localId: invoice.localId,
+      fileName: normalizeTarFileName(invoice.fileName),
+      invoiceHash: sha256Base64(invoiceBuffer),
+      invoiceSize: invoiceBuffer.byteLength
+    };
+  });
+}
+
+function buildTarGz(invoices: BatchInvoiceInput[]): Buffer {
+  const tarEntries: Buffer[] = [];
+
+  for (const invoice of invoices) {
+    const fileName = normalizeTarFileName(invoice.fileName);
+    const content = toBuffer(invoice.xml);
+    tarEntries.push(createTarHeader(fileName, content.byteLength));
+    tarEntries.push(content);
+    const padding = (512 - (content.byteLength % 512)) % 512;
+    if (padding > 0) {
+      tarEntries.push(Buffer.alloc(padding));
+    }
+  }
+
+  tarEntries.push(Buffer.alloc(1024));
+  return gzipSync(Buffer.concat(tarEntries), {
+    level: zlibConstants.Z_BEST_COMPRESSION
+  });
+}
+
+function createTarHeader(fileName: string, size: number): Buffer {
+  const header = Buffer.alloc(512, 0);
+  header.write(fileName, 0, 100, 'utf8');
+  writeTarOctal(header, 0o644, 100, 8);
+  writeTarOctal(header, 0, 108, 8);
+  writeTarOctal(header, 0, 116, 8);
+  writeTarOctal(header, size, 124, 12);
+  writeTarOctal(header, 0, 136, 12);
+  header.fill(0x20, 148, 156);
+  header.write('0', 156, 1, 'ascii');
+  header.write('ustar\0', 257, 6, 'ascii');
+  header.write('00', 263, 2, 'ascii');
+
+  let checksum = 0;
+  for (const byte of header) {
+    checksum += byte;
+  }
+  const checksumValue = checksum.toString(8).padStart(6, '0');
+  header.write(`${checksumValue}\0 `, 148, 8, 'ascii');
+  return header;
+}
+
+function writeTarOctal(header: Buffer, value: number, offset: number, length: number): void {
+  const valueString = value.toString(8);
+  if (valueString.length > length - 1) {
+    throw new Error(`Tar header value ${value} does not fit in ${length} bytes`);
+  }
+  header.write(`${valueString.padStart(length - 1, '0')}\0`, offset, length, 'ascii');
+}
+
+function splitBuffer(buffer: Buffer, partSizeBytes: number): Buffer[] {
+  const parts: Buffer[] = [];
+  for (let offset = 0; offset < buffer.length; offset += partSizeBytes) {
+    parts.push(buffer.subarray(offset, Math.min(offset + partSizeBytes, buffer.length)));
+  }
+  return parts;
+}
+
+function encryptPart(part: Buffer, encryptionMaterial: SymmetricKeyMaterial): Buffer {
+  const cipher = createCipheriv(
+    'aes-256-cbc',
+    encryptionMaterial.symmetricKey,
+    encryptionMaterial.initializationVector
+  );
+  return Buffer.concat([cipher.update(part), cipher.final()]);
+}
+
+function toBuffer(value: string | Buffer): Buffer {
+  return Buffer.isBuffer(value) ? value : Buffer.from(value, 'utf8');
+}
+
+function normalizeTarFileName(fileName: string): string {
+  const normalized = fileName.replace(/\\/g, '/');
+  if (!normalized || normalized.startsWith('/') || normalized.includes('..') || normalized.includes('\0')) {
+    throw new Error(`Invalid invoice fileName: ${fileName}`);
+  }
+  if (Buffer.byteLength(normalized, 'utf8') > 100) {
+    throw new Error(`Invoice fileName is too long for the built-in tar writer: ${fileName}`);
+  }
+  return normalized;
+}
+
+function assertUnique(values: string[], label: string): void {
+  const seen = new Set<string>();
+  for (const value of values) {
+    if (seen.has(value)) {
+      throw new Error(`Batch contains duplicate ${label}: ${value}`);
+    }
+    seen.add(value);
+  }
+}
+
+async function runWithConcurrency<T>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T) => Promise<void>
+): Promise<void> {
+  let nextIndex = 0;
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+    while (nextIndex < items.length) {
+      const item = items[nextIndex++]!;
+      await worker(item);
+    }
+  });
+  await Promise.all(workers);
+}
+
+function mergeSessionInvoices(
+  invoices: SessionInvoiceStatus[],
+  failedInvoices: SessionInvoiceStatus[]
+): SessionInvoiceStatus[] {
+  const merged = new Map<string, SessionInvoiceStatus>();
+  for (const invoice of [...invoices, ...failedInvoices]) {
+    merged.set(invoice.referenceNumber || `${invoice.invoiceHash}:${invoice.ordinalNumber}`, invoice);
+  }
+  return Array.from(merged.values());
+}
+
+function buildPaginationOptions(
+  continuationToken: string | undefined,
+  pageSize: number | undefined
+): { continuationToken?: string; pageSize?: number } {
+  const options: { continuationToken?: string; pageSize?: number } = {};
+  if (continuationToken !== undefined) {
+    options.continuationToken = continuationToken;
+  }
+  if (pageSize !== undefined) {
+    options.pageSize = pageSize;
+  }
+  return options;
+}
+
+function sleep(delayMs: number): Promise<void> {
+  if (delayMs <= 0) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
 }

--- a/src/api2/batch.ts
+++ b/src/api2/batch.ts
@@ -1,15 +1,10 @@
-import { createCipheriv, createHash } from 'node:crypto';
-import { gzipSync, constants as zlibConstants } from 'node:zlib';
 import type { HttpClient } from '@/utils/http.js';
 import type {
   ApiV2Environment,
   BatchFileInfo,
   BatchFilePartInfo,
-  CompressionType,
-  FormCode,
   PartUploadRequest
 } from './types/common.js';
-import type { SymmetricKeyMaterial } from './crypto/symmetric.js';
 import { SymmetricKeyManager } from './crypto/symmetric.js';
 import { SecurityService } from './security.js';
 import type {
@@ -19,132 +14,37 @@ import type {
 } from './types/session.js';
 import {
   BatchSessionUploader,
-  type OpenBatchSessionOptions,
-  type OpenBatchSessionResult,
   SessionV2Service
 } from './services/sessions.js';
+import { buildManifest, buildTarGz } from './batch/archive.js';
+import { encryptPart, sha256Base64 } from './batch/crypto.js';
+import { correlateBatchResults, mergeSessionInvoices } from './batch/results.js';
+import type {
+  BatchListOptions,
+  BatchManifestItem,
+  BatchPrepareOptions,
+  BatchResultCorrelation,
+  BatchSubmitOptions,
+  BatchWaitForCompletionOptions,
+  PreparedBatch,
+  SubmittedBatch
+} from './batch/types.js';
 
-export interface BatchFileBuildResult {
-  batchFile: BatchFileInfo;
-  parts: Buffer[];
-}
-
-export interface BatchInvoiceInput {
-  localId: string;
-  fileName: string;
-  xml: string | Buffer;
-}
-
-export interface BatchManifestItem {
-  localId: string;
-  fileName: string;
-  invoiceHash: string;
-  invoiceSize: number;
-}
-
-export interface BatchPrepareOptions {
-  formCode: FormCode;
-  invoices: BatchInvoiceInput[];
-  /**
-   * High-level preparation currently builds tar.gz archives. The low-level
-   * helpers remain available for callers that already own another archive.
-   */
-  compression?: Extract<CompressionType, 'TarGz'>;
-  /** KSeF limit: parts are split before encryption and cannot exceed 100 MB. */
-  partSizeBytes?: number;
-  encryptionMaterial?: SymmetricKeyMaterial;
-}
-
-export interface PreparedBatch {
-  formCode: FormCode;
-  compressionType: Extract<CompressionType, 'TarGz'>;
-  batchFile: BatchFileInfo;
-  encryptedParts: Buffer[];
-  manifest: BatchManifestItem[];
-  encryptionMaterial: SymmetricKeyMaterial;
-  archiveSize: number;
-  archiveHash: string;
-  partSizeBytes: number;
-}
-
-export interface BatchSubmitOptions {
-  uploadConcurrency?: number;
-  closeSession?: boolean;
-  session?: Omit<OpenBatchSessionOptions, 'encryptionMaterial'>;
-}
-
-export interface SubmittedBatch {
-  referenceNumber: string;
-  session: OpenBatchSessionResult;
-  batchFile: BatchFileInfo;
-  manifest: BatchManifestItem[];
-  partUploadRequests: PartUploadRequest[];
-}
-
-export interface BatchWaitForCompletionOptions {
-  initialDelayMs?: number;
-  maxDelayMs?: number;
-  backoffFactor?: number;
-  timeoutMs?: number;
-  maxAttempts?: number;
-  isTerminal?: (status: SessionStatusResponse) => boolean;
-}
-
-export interface BatchListOptions {
-  pageSize?: number;
-}
-
-export interface BatchCorrelatedResult {
-  localId: string;
-  fileName: string;
-  invoiceHash: string;
-  invoiceSize: number;
-  sessionInvoice: SessionInvoiceStatus;
-}
-
-export interface BatchResultCorrelation {
-  matched: BatchCorrelatedResult[];
-  unmatchedSessionInvoices: SessionInvoiceStatus[];
-  missingManifestItems: BatchManifestItem[];
-}
-
-export class BatchFileBuilder {
-  constructor(private readonly buffer: Buffer) {}
-
-  build(
-    partSize = 5 * 1024 * 1024,
-    options: { compressionType?: CompressionType | null } = {}
-  ): BatchFileBuildResult {
-    const parts: Buffer[] = [];
-    const partInfos: BatchFilePartInfo[] = [];
-
-    for (let offset = 0, ordinal = 1; offset < this.buffer.length; offset += partSize, ordinal++) {
-      const part = this.buffer.subarray(offset, Math.min(offset + partSize, this.buffer.length));
-      parts.push(part);
-      partInfos.push({
-        ordinalNumber: ordinal,
-        fileSize: part.byteLength,
-        fileHash: sha256Base64(part)
-      });
-    }
-
-    return {
-      batchFile: {
-        fileSize: this.buffer.byteLength,
-        fileHash: sha256Base64(this.buffer),
-        ...(options.compressionType ? { compressionType: options.compressionType } : {}),
-        fileParts: partInfos
-      },
-      parts
-    };
-  }
-}
-
-export function sha256Base64(buffer: Buffer): string {
-  const hash = createHash('sha256');
-  hash.update(buffer);
-  return hash.digest('base64');
-}
+export { BatchFileBuilder } from './batch/file-builder.js';
+export { sha256Base64 } from './batch/crypto.js';
+export type {
+  BatchCorrelatedResult,
+  BatchFileBuildResult,
+  BatchInvoiceInput,
+  BatchListOptions,
+  BatchManifestItem,
+  BatchPrepareOptions,
+  BatchResultCorrelation,
+  BatchSubmitOptions,
+  BatchWaitForCompletionOptions,
+  PreparedBatch,
+  SubmittedBatch
+} from './batch/types.js';
 
 export class KsefBatchService {
   private readonly symmetricManager: SymmetricKeyManager;
@@ -308,32 +208,7 @@ export class KsefBatchService {
     manifest: BatchManifestItem[],
     sessionInvoices: SessionInvoiceStatus[]
   ): BatchResultCorrelation {
-    const manifestByHash = new Map(manifest.map((item) => [item.invoiceHash, item]));
-    const matched: BatchCorrelatedResult[] = [];
-    const unmatchedSessionInvoices: SessionInvoiceStatus[] = [];
-    const matchedHashes = new Set<string>();
-
-    for (const sessionInvoice of sessionInvoices) {
-      const manifestItem = manifestByHash.get(sessionInvoice.invoiceHash);
-      if (!manifestItem) {
-        unmatchedSessionInvoices.push(sessionInvoice);
-        continue;
-      }
-      matched.push({
-        localId: manifestItem.localId,
-        fileName: manifestItem.fileName,
-        invoiceHash: manifestItem.invoiceHash,
-        invoiceSize: manifestItem.invoiceSize,
-        sessionInvoice
-      });
-      matchedHashes.add(manifestItem.invoiceHash);
-    }
-
-    return {
-      matched,
-      unmatchedSessionInvoices,
-      missingManifestItems: manifest.filter((item) => !matchedHashes.has(item.invoiceHash))
-    };
+    return correlateBatchResults(manifest, sessionInvoices);
   }
 
   async getMappedResults(
@@ -396,98 +271,12 @@ export class KsefBatchService {
   }
 }
 
-function buildManifest(invoices: BatchInvoiceInput[]): BatchManifestItem[] {
-  return invoices.map((invoice) => {
-    const invoiceBuffer = toBuffer(invoice.xml);
-    return {
-      localId: invoice.localId,
-      fileName: normalizeTarFileName(invoice.fileName),
-      invoiceHash: sha256Base64(invoiceBuffer),
-      invoiceSize: invoiceBuffer.byteLength
-    };
-  });
-}
-
-function buildTarGz(invoices: BatchInvoiceInput[]): Buffer {
-  const tarEntries: Buffer[] = [];
-
-  for (const invoice of invoices) {
-    const fileName = normalizeTarFileName(invoice.fileName);
-    const content = toBuffer(invoice.xml);
-    tarEntries.push(createTarHeader(fileName, content.byteLength));
-    tarEntries.push(content);
-    const padding = (512 - (content.byteLength % 512)) % 512;
-    if (padding > 0) {
-      tarEntries.push(Buffer.alloc(padding));
-    }
-  }
-
-  tarEntries.push(Buffer.alloc(1024));
-  return gzipSync(Buffer.concat(tarEntries), {
-    level: zlibConstants.Z_BEST_COMPRESSION
-  });
-}
-
-function createTarHeader(fileName: string, size: number): Buffer {
-  const header = Buffer.alloc(512, 0);
-  header.write(fileName, 0, 100, 'utf8');
-  writeTarOctal(header, 0o644, 100, 8);
-  writeTarOctal(header, 0, 108, 8);
-  writeTarOctal(header, 0, 116, 8);
-  writeTarOctal(header, size, 124, 12);
-  writeTarOctal(header, 0, 136, 12);
-  header.fill(0x20, 148, 156);
-  header.write('0', 156, 1, 'ascii');
-  header.write('ustar\0', 257, 6, 'ascii');
-  header.write('00', 263, 2, 'ascii');
-
-  let checksum = 0;
-  for (const byte of header) {
-    checksum += byte;
-  }
-  const checksumValue = checksum.toString(8).padStart(6, '0');
-  header.write(`${checksumValue}\0 `, 148, 8, 'ascii');
-  return header;
-}
-
-function writeTarOctal(header: Buffer, value: number, offset: number, length: number): void {
-  const valueString = value.toString(8);
-  if (valueString.length > length - 1) {
-    throw new Error(`Tar header value ${value} does not fit in ${length} bytes`);
-  }
-  header.write(`${valueString.padStart(length - 1, '0')}\0`, offset, length, 'ascii');
-}
-
 function splitBuffer(buffer: Buffer, partSizeBytes: number): Buffer[] {
   const parts: Buffer[] = [];
   for (let offset = 0; offset < buffer.length; offset += partSizeBytes) {
     parts.push(buffer.subarray(offset, Math.min(offset + partSizeBytes, buffer.length)));
   }
   return parts;
-}
-
-function encryptPart(part: Buffer, encryptionMaterial: SymmetricKeyMaterial): Buffer {
-  const cipher = createCipheriv(
-    'aes-256-cbc',
-    encryptionMaterial.symmetricKey,
-    encryptionMaterial.initializationVector
-  );
-  return Buffer.concat([cipher.update(part), cipher.final()]);
-}
-
-function toBuffer(value: string | Buffer): Buffer {
-  return Buffer.isBuffer(value) ? value : Buffer.from(value, 'utf8');
-}
-
-function normalizeTarFileName(fileName: string): string {
-  const normalized = fileName.replace(/\\/g, '/');
-  if (!normalized || normalized.startsWith('/') || normalized.includes('..') || normalized.includes('\0')) {
-    throw new Error(`Invalid invoice fileName: ${fileName}`);
-  }
-  if (Buffer.byteLength(normalized, 'utf8') > 100) {
-    throw new Error(`Invoice fileName is too long for the built-in tar writer: ${fileName}`);
-  }
-  return normalized;
 }
 
 function assertUnique(values: string[], label: string): void {
@@ -513,17 +302,6 @@ async function runWithConcurrency<T>(
     }
   });
   await Promise.all(workers);
-}
-
-function mergeSessionInvoices(
-  invoices: SessionInvoiceStatus[],
-  failedInvoices: SessionInvoiceStatus[]
-): SessionInvoiceStatus[] {
-  const merged = new Map<string, SessionInvoiceStatus>();
-  for (const invoice of [...invoices, ...failedInvoices]) {
-    merged.set(invoice.referenceNumber || `${invoice.invoiceHash}:${invoice.ordinalNumber}`, invoice);
-  }
-  return Array.from(merged.values());
 }
 
 function buildPaginationOptions(

--- a/src/api2/batch/archive.ts
+++ b/src/api2/batch/archive.ts
@@ -14,6 +14,13 @@ export function buildManifest(invoices: BatchInvoiceInput[]): BatchManifestItem[
   });
 }
 
+export function estimateTarSize(manifest: BatchManifestItem[]): number {
+  return manifest.reduce(
+    (size, item) => size + 512 + item.invoiceSize + tarPadding(item.invoiceSize),
+    1024
+  );
+}
+
 export function buildTarGz(invoices: BatchInvoiceInput[]): Buffer {
   const tarEntries: Buffer[] = [];
 
@@ -22,7 +29,7 @@ export function buildTarGz(invoices: BatchInvoiceInput[]): Buffer {
     const content = toBuffer(invoice.xml);
     tarEntries.push(createTarHeader(fileName, content.byteLength));
     tarEntries.push(content);
-    const padding = (512 - (content.byteLength % 512)) % 512;
+    const padding = tarPadding(content.byteLength);
     if (padding > 0) {
       tarEntries.push(Buffer.alloc(padding));
     }
@@ -62,6 +69,10 @@ function writeTarOctal(header: Buffer, value: number, offset: number, length: nu
     throw new Error(`Tar header value ${value} does not fit in ${length} bytes`);
   }
   header.write(`${valueString.padStart(length - 1, '0')}\0`, offset, length, 'ascii');
+}
+
+function tarPadding(size: number): number {
+  return (512 - (size % 512)) % 512;
 }
 
 function toBuffer(value: string | Buffer): Buffer {

--- a/src/api2/batch/archive.ts
+++ b/src/api2/batch/archive.ts
@@ -1,0 +1,80 @@
+import { gzipSync, constants as zlibConstants } from 'node:zlib';
+import type { BatchInvoiceInput, BatchManifestItem } from './types.js';
+import { sha256Base64 } from './crypto.js';
+
+export function buildManifest(invoices: BatchInvoiceInput[]): BatchManifestItem[] {
+  return invoices.map((invoice) => {
+    const invoiceBuffer = toBuffer(invoice.xml);
+    return {
+      localId: invoice.localId,
+      fileName: normalizeTarFileName(invoice.fileName),
+      invoiceHash: sha256Base64(invoiceBuffer),
+      invoiceSize: invoiceBuffer.byteLength
+    };
+  });
+}
+
+export function buildTarGz(invoices: BatchInvoiceInput[]): Buffer {
+  const tarEntries: Buffer[] = [];
+
+  for (const invoice of invoices) {
+    const fileName = normalizeTarFileName(invoice.fileName);
+    const content = toBuffer(invoice.xml);
+    tarEntries.push(createTarHeader(fileName, content.byteLength));
+    tarEntries.push(content);
+    const padding = (512 - (content.byteLength % 512)) % 512;
+    if (padding > 0) {
+      tarEntries.push(Buffer.alloc(padding));
+    }
+  }
+
+  tarEntries.push(Buffer.alloc(1024));
+  return gzipSync(Buffer.concat(tarEntries), {
+    level: zlibConstants.Z_BEST_COMPRESSION
+  });
+}
+
+function createTarHeader(fileName: string, size: number): Buffer {
+  const header = Buffer.alloc(512, 0);
+  header.write(fileName, 0, 100, 'utf8');
+  writeTarOctal(header, 0o644, 100, 8);
+  writeTarOctal(header, 0, 108, 8);
+  writeTarOctal(header, 0, 116, 8);
+  writeTarOctal(header, size, 124, 12);
+  writeTarOctal(header, 0, 136, 12);
+  header.fill(0x20, 148, 156);
+  header.write('0', 156, 1, 'ascii');
+  header.write('ustar\0', 257, 6, 'ascii');
+  header.write('00', 263, 2, 'ascii');
+
+  let checksum = 0;
+  for (const byte of header) {
+    checksum += byte;
+  }
+  const checksumValue = checksum.toString(8).padStart(6, '0');
+  header.write(`${checksumValue}\0 `, 148, 8, 'ascii');
+  return header;
+}
+
+function writeTarOctal(header: Buffer, value: number, offset: number, length: number): void {
+  const valueString = value.toString(8);
+  if (valueString.length > length - 1) {
+    throw new Error(`Tar header value ${value} does not fit in ${length} bytes`);
+  }
+  header.write(`${valueString.padStart(length - 1, '0')}\0`, offset, length, 'ascii');
+}
+
+function toBuffer(value: string | Buffer): Buffer {
+  return Buffer.isBuffer(value) ? value : Buffer.from(value, 'utf8');
+}
+
+function normalizeTarFileName(fileName: string): string {
+  const normalized = fileName.replace(/\\/g, '/');
+  if (!normalized || normalized.startsWith('/') || normalized.includes('..') || normalized.includes('\0')) {
+    throw new Error(`Invalid invoice fileName: ${fileName}`);
+  }
+  if (Buffer.byteLength(normalized, 'utf8') > 100) {
+    throw new Error(`Invoice fileName is too long for the built-in tar writer: ${fileName}`);
+  }
+  return normalized;
+}

--- a/src/api2/batch/crypto.ts
+++ b/src/api2/batch/crypto.ts
@@ -1,0 +1,17 @@
+import { createCipheriv, createHash } from 'node:crypto';
+import type { SymmetricKeyMaterial } from '../crypto/symmetric.js';
+
+export function sha256Base64(buffer: Buffer): string {
+  const hash = createHash('sha256');
+  hash.update(buffer);
+  return hash.digest('base64');
+}
+
+export function encryptPart(part: Buffer, encryptionMaterial: SymmetricKeyMaterial): Buffer {
+  const cipher = createCipheriv(
+    'aes-256-cbc',
+    encryptionMaterial.symmetricKey,
+    encryptionMaterial.initializationVector
+  );
+  return Buffer.concat([cipher.update(part), cipher.final()]);
+}

--- a/src/api2/batch/file-builder.ts
+++ b/src/api2/batch/file-builder.ts
@@ -1,0 +1,37 @@
+import type { BatchFileInfo, BatchFilePartInfo, CompressionType } from '../types/common.js';
+import { sha256Base64 } from './crypto.js';
+import type { BatchFileBuildResult } from './types.js';
+
+export class BatchFileBuilder {
+  constructor(private readonly buffer: Buffer) {}
+
+  build(
+    partSize = 5 * 1024 * 1024,
+    options: { compressionType?: CompressionType | null } = {}
+  ): BatchFileBuildResult {
+    const parts: Buffer[] = [];
+    const partInfos: BatchFilePartInfo[] = [];
+
+    for (let offset = 0, ordinal = 1; offset < this.buffer.length; offset += partSize, ordinal++) {
+      const part = this.buffer.subarray(offset, Math.min(offset + partSize, this.buffer.length));
+      parts.push(part);
+      partInfos.push({
+        ordinalNumber: ordinal,
+        fileSize: part.byteLength,
+        fileHash: sha256Base64(part)
+      });
+    }
+
+    const batchFile: BatchFileInfo = {
+      fileSize: this.buffer.byteLength,
+      fileHash: sha256Base64(this.buffer),
+      ...(options.compressionType ? { compressionType: options.compressionType } : {}),
+      fileParts: partInfos
+    };
+
+    return {
+      batchFile,
+      parts
+    };
+  }
+}

--- a/src/api2/batch/results.ts
+++ b/src/api2/batch/results.ts
@@ -1,0 +1,49 @@
+import type { SessionInvoiceStatus } from '../types/session.js';
+import type {
+  BatchCorrelatedResult,
+  BatchManifestItem,
+  BatchResultCorrelation
+} from './types.js';
+
+export function correlateBatchResults(
+  manifest: BatchManifestItem[],
+  sessionInvoices: SessionInvoiceStatus[]
+): BatchResultCorrelation {
+  const manifestByHash = new Map(manifest.map((item) => [item.invoiceHash, item]));
+  const matched: BatchCorrelatedResult[] = [];
+  const unmatchedSessionInvoices: SessionInvoiceStatus[] = [];
+  const matchedHashes = new Set<string>();
+
+  for (const sessionInvoice of sessionInvoices) {
+    const manifestItem = manifestByHash.get(sessionInvoice.invoiceHash);
+    if (!manifestItem) {
+      unmatchedSessionInvoices.push(sessionInvoice);
+      continue;
+    }
+    matched.push({
+      localId: manifestItem.localId,
+      fileName: manifestItem.fileName,
+      invoiceHash: manifestItem.invoiceHash,
+      invoiceSize: manifestItem.invoiceSize,
+      sessionInvoice
+    });
+    matchedHashes.add(manifestItem.invoiceHash);
+  }
+
+  return {
+    matched,
+    unmatchedSessionInvoices,
+    missingManifestItems: manifest.filter((item) => !matchedHashes.has(item.invoiceHash))
+  };
+}
+
+export function mergeSessionInvoices(
+  invoices: SessionInvoiceStatus[],
+  failedInvoices: SessionInvoiceStatus[]
+): SessionInvoiceStatus[] {
+  const merged = new Map<string, SessionInvoiceStatus>();
+  for (const invoice of [...invoices, ...failedInvoices]) {
+    merged.set(invoice.referenceNumber || `${invoice.invoiceHash}:${invoice.ordinalNumber}`, invoice);
+  }
+  return Array.from(merged.values());
+}

--- a/src/api2/batch/types.ts
+++ b/src/api2/batch/types.ts
@@ -1,0 +1,88 @@
+import type { BatchFileInfo, CompressionType, FormCode, PartUploadRequest } from '../types/common.js';
+import type { SymmetricKeyMaterial } from '../crypto/symmetric.js';
+import type { SessionInvoiceStatus, SessionStatusResponse } from '../types/session.js';
+import type { OpenBatchSessionOptions, OpenBatchSessionResult } from '../services/sessions.js';
+
+export interface BatchFileBuildResult {
+  batchFile: BatchFileInfo;
+  parts: Buffer[];
+}
+
+export interface BatchInvoiceInput {
+  localId: string;
+  fileName: string;
+  xml: string | Buffer;
+}
+
+export interface BatchManifestItem {
+  localId: string;
+  fileName: string;
+  invoiceHash: string;
+  invoiceSize: number;
+}
+
+export interface BatchPrepareOptions {
+  formCode: FormCode;
+  invoices: BatchInvoiceInput[];
+  /**
+   * High-level preparation currently builds tar.gz archives. The low-level
+   * helpers remain available for callers that already own another archive.
+   */
+  compression?: Extract<CompressionType, 'TarGz'>;
+  /** KSeF limit: parts are split before encryption and cannot exceed 100 MB. */
+  partSizeBytes?: number;
+  encryptionMaterial?: SymmetricKeyMaterial;
+}
+
+export interface PreparedBatch {
+  formCode: FormCode;
+  compressionType: Extract<CompressionType, 'TarGz'>;
+  batchFile: BatchFileInfo;
+  encryptedParts: Buffer[];
+  manifest: BatchManifestItem[];
+  encryptionMaterial: SymmetricKeyMaterial;
+  archiveSize: number;
+  archiveHash: string;
+  partSizeBytes: number;
+}
+
+export interface BatchSubmitOptions {
+  uploadConcurrency?: number;
+  closeSession?: boolean;
+  session?: Omit<OpenBatchSessionOptions, 'encryptionMaterial'>;
+}
+
+export interface SubmittedBatch {
+  referenceNumber: string;
+  session: OpenBatchSessionResult;
+  batchFile: BatchFileInfo;
+  manifest: BatchManifestItem[];
+  partUploadRequests: PartUploadRequest[];
+}
+
+export interface BatchWaitForCompletionOptions {
+  initialDelayMs?: number;
+  maxDelayMs?: number;
+  backoffFactor?: number;
+  timeoutMs?: number;
+  maxAttempts?: number;
+  isTerminal?: (status: SessionStatusResponse) => boolean;
+}
+
+export interface BatchListOptions {
+  pageSize?: number;
+}
+
+export interface BatchCorrelatedResult {
+  localId: string;
+  fileName: string;
+  invoiceHash: string;
+  invoiceSize: number;
+  sessionInvoice: SessionInvoiceStatus;
+}
+
+export interface BatchResultCorrelation {
+  matched: BatchCorrelatedResult[];
+  unmatchedSessionInvoices: SessionInvoiceStatus[];
+  missingManifestItems: BatchManifestItem[];
+}

--- a/src/api2/batch/types.ts
+++ b/src/api2/batch/types.ts
@@ -31,6 +31,11 @@ export interface BatchPrepareOptions {
   compression?: Extract<CompressionType, 'TarGz'>;
   /** KSeF limit: parts are split before encryption and cannot exceed 100 MB. */
   partSizeBytes?: number;
+  /**
+   * Safety cap for the buffered prepare flow, measured as tar size before gzip.
+   * Defaults to 256 MiB. Raise only when the caller controls process memory.
+   */
+  maxUncompressedArchiveSizeBytes?: number;
   encryptionMaterial?: SymmetricKeyMaterial;
 }
 

--- a/src/api2/client.ts
+++ b/src/api2/client.ts
@@ -35,8 +35,9 @@ import type {
 } from './types/invoice.js';
 import type { SessionStatusResponse, SessionInvoicesResponse } from './types/session.js';
 import type { FormCode as BatchFormCode, PartUploadRequest } from './types/common.js';
+import type { CompressionType } from './types/common.js';
 import type { BatchFileBuildResult } from './batch.js';
-import { BatchFileBuilder } from './batch.js';
+import { BatchFileBuilder, KsefBatchService } from './batch.js';
 
 export interface KsefApiV2ClientOptions {
   environment: ApiV2Environment;
@@ -48,6 +49,7 @@ export class KsefApiV2Client {
   readonly authentication: AuthenticationV2Service;
   readonly sessions: SessionV2Service;
   readonly invoices: InvoiceV2Service;
+  readonly batch: KsefBatchService;
   readonly batchUploader: BatchSessionUploader;
   readonly permissions: PermissionsV2Service;
   readonly tokens: TokenService;
@@ -69,6 +71,7 @@ export class KsefApiV2Client {
     this.peppol = new PeppolService(this.httpClient, options.environment);
     this.certificates = new CertificateService(this.httpClient, options.environment);
     this.batchUploader = new BatchSessionUploader();
+    this.batch = new KsefBatchService(this.sessions, this.batchUploader, this.httpClient, options.environment);
 
     this.authManager = options.authManager ?? new DefaultAuthManager(async () => {
       const refreshToken = this.authManager.getRefreshToken();
@@ -178,19 +181,23 @@ export class KsefApiV2Client {
     accessToken: string,
     formCode: BatchFormCode,
     batchBuffer: Buffer,
-    options?: { partSize?: number; session?: OpenBatchSessionOptions }
+    options?: { partSize?: number; compressionType?: CompressionType | null; session?: OpenBatchSessionOptions }
   ): Promise<{ session: Awaited<ReturnType<SessionV2Service['openBatchSession']>>; batchParts: BatchFileBuildResult['parts'] }>;
   async createBatchSession(
     accessToken: string,
     formCode: BatchFormCode,
     batchBuffer: Buffer,
-    partSizeOrOptions?: number | { partSize?: number; session?: OpenBatchSessionOptions }
+    partSizeOrOptions?: number | { partSize?: number; compressionType?: CompressionType | null; session?: OpenBatchSessionOptions }
   ): Promise<{ session: Awaited<ReturnType<SessionV2Service['openBatchSession']>>; batchParts: BatchFileBuildResult['parts'] }> {
     const partSize = typeof partSizeOrOptions === 'number' ? partSizeOrOptions : partSizeOrOptions?.partSize;
+    const compressionType = typeof partSizeOrOptions === 'number' ? undefined : partSizeOrOptions?.compressionType;
     const sessionOptions = typeof partSizeOrOptions === 'number' ? undefined : partSizeOrOptions?.session;
 
     const builder = new BatchFileBuilder(batchBuffer);
-    const batch = builder.build(partSize);
+    const batch = builder.build(
+      partSize,
+      compressionType === undefined ? {} : { compressionType }
+    );
     const session = await this.sessions.openBatchSession(accessToken, batch.batchFile, formCode, sessionOptions);
     return { session, batchParts: batch.parts };
   }

--- a/src/api2/index.ts
+++ b/src/api2/index.ts
@@ -43,7 +43,7 @@ export * from './crypto/symmetric.js';
 export * from './crypto/encryption.js';
 export * from './auth/xades-request.js';
 export { HttpClient } from '../utils/http.js';
-export type { HttpClientOptions } from '../types/config.js';
+export type { HttpClientOptions, SystemWarningInfo } from '../types/config.js';
 export * from '../types/limits.js';
 export * from './rate-limits.js';
 export * from './qr/index.js';

--- a/src/api2/index.ts
+++ b/src/api2/index.ts
@@ -10,6 +10,22 @@ export * from './types/peppol.js';
 export * from './types/certificates.js';
 export * from './client.js';
 export * from './auth-manager.js';
+export {
+  BatchFileBuilder,
+  KsefBatchService
+} from './batch.js';
+export type {
+  BatchCorrelatedResult,
+  BatchInvoiceInput,
+  BatchListOptions,
+  BatchManifestItem,
+  BatchPrepareOptions,
+  BatchResultCorrelation,
+  BatchSubmitOptions,
+  BatchWaitForCompletionOptions,
+  PreparedBatch,
+  SubmittedBatch
+} from './batch.js';
 export * from './routes.js';
 export * from './services/authentication.js';
 export * from './services/auth-sessions.js';

--- a/src/api2/types/common.ts
+++ b/src/api2/types/common.ts
@@ -113,6 +113,7 @@ export interface FormCode {
 }
 
 export type UpoVersion = 'upo-v4-2' | 'upo-v4-3';
+export type CompressionType = 'Zip' | 'TarGz';
 
 export interface EncryptionInfo {
   encryptedSymmetricKey: string;
@@ -138,6 +139,7 @@ export interface BatchFilePartInfo {
 export interface BatchFileInfo {
   fileSize: number;
   fileHash: string;
+  compressionType?: CompressionType | null;
   fileParts: BatchFilePartInfo[];
 }
 

--- a/src/api2/types/invoice.ts
+++ b/src/api2/types/invoice.ts
@@ -1,4 +1,10 @@
-import type { ApiV2ResponseStatus, EncryptionInfo, FormCode, Sha256HashBase64 } from './common.js';
+import type {
+  ApiV2ResponseStatus,
+  CompressionType,
+  EncryptionInfo,
+  FormCode,
+  Sha256HashBase64
+} from './common.js';
 
 export interface SendInvoiceRequestPayload {
   invoiceHash: Sha256HashBase64;
@@ -144,6 +150,7 @@ export interface QueryInvoicesMetadataResponse {
 export interface InvoiceExportRequest {
   encryption: EncryptionInfo;
   filters: InvoiceQueryFilters;
+  compressionType?: CompressionType | null;
 }
 
 export interface ExportInvoicesResponse {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -5,6 +5,15 @@ import type { AuthManager } from '@/api2/auth-manager.js';
  * Shared HTTP client configuration used by the API v2 services.
  */
 
+export interface SystemWarningInfo {
+  code: string;
+  message: string;
+  raw: string;
+  method: string;
+  url: string;
+  status: number;
+}
+
 export interface HttpClientOptions {
   /** Request timeout in milliseconds (default: 30000) */
   timeout?: number;
@@ -29,4 +38,7 @@ export interface HttpClientOptions {
 
   /** Optional token manager used for auth header injection and 401 refresh */
   authManager?: AuthManager;
+
+  /** Called when KSeF returns the X-System-Warning response header */
+  onSystemWarning?: (warning: SystemWarningInfo) => void;
 }

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -4,7 +4,7 @@
 
 import { request } from 'node:https';
 import { Agent } from 'node:https';
-import type { HttpClientOptions } from '@/types/config.js';
+import type { HttpClientOptions, SystemWarningInfo } from '@/types/config.js';
 import { KsefApiError, AuthenticationError, ValidationError } from '@/types/common.js';
 import { RateLimiter, createRateLimiter } from './rate-limiter.js';
 import type { RateLimitError } from '@/types/limits.js';
@@ -34,9 +34,10 @@ export interface HttpResponse<T = any> {
 
 export class HttpClient {
   private readonly agent: Agent;
-  private readonly options: Required<Omit<HttpClientOptions, 'rateLimitConfig' | 'authManager'>>;
+  private readonly options: Required<Omit<HttpClientOptions, 'rateLimitConfig' | 'authManager' | 'onSystemWarning'>>;
   private readonly rateLimiter?: RateLimiter;
   private authManager: AuthManager | undefined;
+  private readonly onSystemWarning: ((warning: SystemWarningInfo) => void) | undefined;
 
   constructor(options: HttpClientOptions = {}) {
     this.options = {
@@ -47,6 +48,7 @@ export class HttpClient {
       headers: options.headers ?? {},
       userAgent: options.userAgent ?? 'KSeF-TypeScript-Client/1.7.0'
     };
+    this.onSystemWarning = options.onSystemWarning;
 
     // Initialize rate limiter if configured
     if (options.rateLimitConfig) {
@@ -76,7 +78,9 @@ export class HttpClient {
         }
 
         const requestWithAuth = this.withManagedAuthorization(currentOptions);
-        return await this.executeRequest<T>(requestWithAuth, url);
+        const response = await this.executeRequest<T>(requestWithAuth, url);
+        this.emitSystemWarnings(response, requestWithAuth, url);
+        return response;
       } catch (error) {
         lastError = error instanceof Error ? error : new Error('Unknown error');
 
@@ -198,6 +202,7 @@ export class HttpClient {
             };
 
             if (res.statusCode && res.statusCode >= 400) {
+              this.emitSystemWarnings(response, requestOptions, url);
               this.handleErrorResponse(response);
             } else {
               resolve(response);
@@ -331,6 +336,55 @@ export class HttpClient {
       merged.Authorization = value;
     }
     return merged;
+  }
+
+  private emitSystemWarnings<T>(
+    response: HttpResponse<T>,
+    requestOptions: HttpRequestOptions,
+    url: URL
+  ): void {
+    if (!this.onSystemWarning) {
+      return;
+    }
+
+    const headerValue = this.getHeader(response.headers, 'x-system-warning');
+    if (!headerValue) {
+      return;
+    }
+
+    for (const warning of this.parseSystemWarningHeader(headerValue)) {
+      this.onSystemWarning({
+        ...warning,
+        raw: headerValue,
+        method: requestOptions.method,
+        url: url.toString(),
+        status: response.status
+      });
+    }
+  }
+
+  private getHeader(headers: Record<string, string>, name: string): string | undefined {
+    const key = Object.keys(headers).find((candidate) => candidate.toLowerCase() === name);
+    return key ? headers[key] : undefined;
+  }
+
+  private parseSystemWarningHeader(value: string): Array<Pick<SystemWarningInfo, 'code' | 'message'>> {
+    const warnings: Array<Pick<SystemWarningInfo, 'code' | 'message'>> = [];
+    const warningPattern = /\[(?<code>[^\]]+)\]: (?<message>[^|]+)/g;
+
+    for (const match of value.matchAll(warningPattern)) {
+      const code = match.groups?.code?.trim();
+      const message = match.groups?.message?.trim();
+      if (code && message) {
+        warnings.push({ code, message });
+      }
+    }
+
+    if (warnings.length > 0) {
+      return warnings;
+    }
+
+    return [{ code: 'UNKNOWN', message: value }];
   }
 
   private isRateLimitError(error: unknown): error is RateLimitError {

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -353,13 +353,17 @@ export class HttpClient {
     }
 
     for (const warning of this.parseSystemWarningHeader(headerValue)) {
-      this.onSystemWarning({
-        ...warning,
-        raw: headerValue,
-        method: requestOptions.method,
-        url: url.toString(),
-        status: response.status
-      });
+      try {
+        this.onSystemWarning({
+          ...warning,
+          raw: headerValue,
+          method: requestOptions.method,
+          url: url.toString(),
+          status: response.status
+        });
+      } catch {
+        // System warning callbacks are observational and must not change HTTP request semantics.
+      }
     }
   }
 

--- a/tests/batch.test.ts
+++ b/tests/batch.test.ts
@@ -258,6 +258,19 @@ describe('KsefBatchService', () => {
         ]
       })).rejects.toThrow(/duplicate invoiceHash/);
     });
+
+    it('rejects batches above the buffered uncompressed archive size limit', async () => {
+      const service = createBatchService();
+
+      await expect(service.prepare({
+        formCode,
+        encryptionMaterial: createTestMaterial(),
+        maxUncompressedArchiveSizeBytes: 2047,
+        invoices: [
+          { localId: 'invoice-1', fileName: 'invoice-1.xml', xml: '<Faktura>1</Faktura>' }
+        ]
+      })).rejects.toThrow(/uncompressed tar size 2048 exceeds buffered prepare limit of 2047 bytes/);
+    });
   });
 
   describe('submit', () => {

--- a/tests/batch.test.ts
+++ b/tests/batch.test.ts
@@ -1,6 +1,40 @@
-import { describe, it, expect } from 'vitest';
-import { createHash } from 'node:crypto';
-import { BatchFileBuilder, sha256Base64 } from '../src/api2/batch.js';
+import { describe, it, expect, vi } from 'vitest';
+import { createDecipheriv, randomBytes } from 'node:crypto';
+import { gunzipSync } from 'node:zlib';
+import {
+  BatchFileBuilder,
+  KsefBatchService,
+  sha256Base64,
+  type PreparedBatch
+} from '../src/api2/batch.js';
+import type { SymmetricKeyMaterial } from '../src/api2/crypto/symmetric.js';
+import type { SessionInvoiceStatus } from '../src/api2/types/session.js';
+
+const formCode = { systemCode: 'FA (3)', schemaVersion: '1-0E', value: 'FA' } as const;
+
+function createTestMaterial(): SymmetricKeyMaterial {
+  const initializationVector = randomBytes(16);
+  return {
+    symmetricKey: randomBytes(32),
+    initializationVector,
+    encryptedSymmetricKey: 'encrypted-key',
+    initializationVectorBase64: initializationVector.toString('base64')
+  };
+}
+
+function decryptPart(part: Buffer, material: SymmetricKeyMaterial): Buffer {
+  const decipher = createDecipheriv('aes-256-cbc', material.symmetricKey, material.initializationVector);
+  return Buffer.concat([decipher.update(part), decipher.final()]);
+}
+
+function createBatchService(sessions: any = {}, uploader: any = {}) {
+  return new KsefBatchService(
+    sessions,
+    uploader,
+    {} as any,
+    'test'
+  );
+}
 
 describe('sha256Base64', () => {
   it('produces correct SHA-256 hash for known input', () => {
@@ -45,6 +79,14 @@ describe('BatchFileBuilder', () => {
       const result = builder.build();
 
       expect(result.batchFile.fileSize).toBe(data.byteLength);
+    });
+
+    it('includes compression type when requested', () => {
+      const data = Buffer.from('test content');
+      const builder = new BatchFileBuilder(data);
+      const result = builder.build(undefined, { compressionType: 'TarGz' });
+
+      expect(result.batchFile.compressionType).toBe('TarGz');
     });
 
     it('splits file into multiple parts at correct boundaries', () => {
@@ -154,3 +196,193 @@ describe('BatchFileBuilder', () => {
   });
 });
 
+describe('KsefBatchService', () => {
+  describe('prepare', () => {
+    it('builds a TarGz archive, encrypted parts, and manifest keyed by local id', async () => {
+      const material = createTestMaterial();
+      const service = createBatchService();
+
+      const prepared = await service.prepare({
+        formCode,
+        encryptionMaterial: material,
+        partSizeBytes: 120,
+        invoices: [
+          { localId: 'invoice-1', fileName: 'invoice-1.xml', xml: '<Faktura>1</Faktura>' },
+          { localId: 'invoice-2', fileName: 'invoice-2.xml', xml: '<Faktura>2</Faktura>' }
+        ]
+      });
+
+      expect(prepared.compressionType).toBe('TarGz');
+      expect(prepared.batchFile.compressionType).toBe('TarGz');
+      expect(prepared.manifest).toEqual([
+        {
+          localId: 'invoice-1',
+          fileName: 'invoice-1.xml',
+          invoiceHash: sha256Base64(Buffer.from('<Faktura>1</Faktura>')),
+          invoiceSize: Buffer.byteLength('<Faktura>1</Faktura>')
+        },
+        {
+          localId: 'invoice-2',
+          fileName: 'invoice-2.xml',
+          invoiceHash: sha256Base64(Buffer.from('<Faktura>2</Faktura>')),
+          invoiceSize: Buffer.byteLength('<Faktura>2</Faktura>')
+        }
+      ]);
+      expect(prepared.batchFile.fileParts).toHaveLength(prepared.encryptedParts.length);
+      prepared.encryptedParts.forEach((part, index) => {
+        expect(prepared.batchFile.fileParts[index]).toMatchObject({
+          ordinalNumber: index + 1,
+          fileSize: part.byteLength,
+          fileHash: sha256Base64(part)
+        });
+      });
+
+      const archive = Buffer.concat(prepared.encryptedParts.map((part) => decryptPart(part, material)));
+      expect(prepared.batchFile.fileHash).toBe(sha256Base64(archive));
+      const tar = gunzipSync(archive);
+      expect(tar.includes(Buffer.from('invoice-1.xml'))).toBe(true);
+      expect(tar.includes(Buffer.from('<Faktura>1</Faktura>'))).toBe(true);
+      expect(tar.includes(Buffer.from('invoice-2.xml'))).toBe(true);
+      expect(tar.includes(Buffer.from('<Faktura>2</Faktura>'))).toBe(true);
+    });
+
+    it('rejects duplicate invoice hashes because results could not be correlated safely', async () => {
+      const service = createBatchService();
+
+      await expect(service.prepare({
+        formCode,
+        encryptionMaterial: createTestMaterial(),
+        invoices: [
+          { localId: 'invoice-1', fileName: 'invoice-1.xml', xml: '<Faktura>same</Faktura>' },
+          { localId: 'invoice-2', fileName: 'invoice-2.xml', xml: '<Faktura>same</Faktura>' }
+        ]
+      })).rejects.toThrow(/duplicate invoiceHash/);
+    });
+  });
+
+  describe('submit', () => {
+    it('opens a batch session with prepared metadata, uploads parts by ordinal number, and closes the session', async () => {
+      const material = createTestMaterial();
+      const sessions = {
+        openBatchSession: vi.fn(),
+        closeBatchSession: vi.fn().mockResolvedValue(undefined)
+      };
+      const uploader = {
+        uploadPart: vi.fn().mockResolvedValue(undefined)
+      };
+      const service = createBatchService(sessions, uploader);
+      const prepared: PreparedBatch = await service.prepare({
+        formCode,
+        encryptionMaterial: material,
+        partSizeBytes: 80,
+        invoices: [{ localId: 'invoice-1', fileName: 'invoice-1.xml', xml: '<Faktura>1</Faktura>' }]
+      });
+      sessions.openBatchSession.mockResolvedValue({
+        referenceNumber: 'batch-ref',
+        partUploadRequests: prepared.encryptedParts
+          .map((_, index) => ({
+            ordinalNumber: index + 1,
+            method: 'PUT' as const,
+            url: `https://upload.test/${index + 1}`,
+            headers: {}
+          }))
+          .reverse(),
+        encryptionMaterial: material
+      });
+
+      const submitted = await service.submit('token', prepared, { uploadConcurrency: 2 });
+
+      expect(submitted.referenceNumber).toBe('batch-ref');
+      expect(sessions.openBatchSession).toHaveBeenCalledWith('token', prepared.batchFile, formCode, {
+        encryptionMaterial: material
+      });
+      expect(uploader.uploadPart).toHaveBeenCalledTimes(prepared.encryptedParts.length);
+      expect(uploader.uploadPart).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ ordinalNumber: 1 }),
+        prepared.encryptedParts[0]
+      );
+      if (prepared.encryptedParts.length > 1) {
+        expect(uploader.uploadPart).toHaveBeenNthCalledWith(
+          2,
+          expect.objectContaining({ ordinalNumber: 2 }),
+          prepared.encryptedParts[1]
+        );
+      }
+      expect(sessions.closeBatchSession).toHaveBeenCalledWith('token', 'batch-ref');
+    });
+  });
+
+  describe('waitForCompletion', () => {
+    it('polls until session status is terminal', async () => {
+      const sessions = {
+        getSessionStatus: vi.fn()
+          .mockResolvedValueOnce({ status: { code: 150, description: 'Processing' } })
+          .mockResolvedValueOnce({ status: { code: 200, description: 'Succeeded' } })
+      };
+      const service = createBatchService(sessions);
+
+      const status = await service.waitForCompletion('token', 'batch-ref', {
+        initialDelayMs: 0,
+        maxDelayMs: 0,
+        maxAttempts: 2
+      });
+
+      expect(status.status.code).toBe(200);
+      expect(sessions.getSessionStatus).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('list and correlation helpers', () => {
+    it('auto-paginates invoice lists and correlates rows by invoiceHash', async () => {
+      const invoiceHash = sha256Base64(Buffer.from('<Faktura>1</Faktura>'));
+      const sessions = {
+        listSessionInvoices: vi.fn()
+          .mockResolvedValueOnce({
+            continuationToken: 'next',
+            invoices: []
+          })
+          .mockResolvedValueOnce({
+            continuationToken: null,
+            invoices: [createSessionInvoice({ invoiceHash, referenceNumber: 'inv-ref' })]
+          }),
+        listFailedSessionInvoices: vi.fn().mockResolvedValue({
+          continuationToken: null,
+          invoices: [createSessionInvoice({ invoiceHash: 'other-hash', referenceNumber: 'failed-ref' })]
+        })
+      };
+      const service = createBatchService(sessions);
+      const manifest = [{
+        localId: 'invoice-1',
+        fileName: 'invoice-1.xml',
+        invoiceHash,
+        invoiceSize: Buffer.byteLength('<Faktura>1</Faktura>')
+      }];
+
+      const result = await service.getMappedResults('token', 'batch-ref', manifest, { pageSize: 10 });
+
+      expect(sessions.listSessionInvoices).toHaveBeenNthCalledWith(1, 'token', 'batch-ref', {
+        pageSize: 10
+      });
+      expect(sessions.listSessionInvoices).toHaveBeenNthCalledWith(2, 'token', 'batch-ref', {
+        continuationToken: 'next',
+        pageSize: 10
+      });
+      expect(result.matched).toHaveLength(1);
+      expect(result.matched[0].localId).toBe('invoice-1');
+      expect(result.unmatchedSessionInvoices).toHaveLength(1);
+      expect(result.missingManifestItems).toHaveLength(0);
+    });
+  });
+});
+
+function createSessionInvoice(overrides: Partial<SessionInvoiceStatus>): SessionInvoiceStatus {
+  return {
+    ordinalNumber: 1,
+    referenceNumber: 'invoice-ref',
+    invoiceHash: 'hash',
+    invoicingDate: '2026-01-01',
+    status: { code: 200, description: 'Accepted' },
+    ...overrides
+  };
+}

--- a/tests/services/invoice.test.ts
+++ b/tests/services/invoice.test.ts
@@ -180,6 +180,31 @@ describe('InvoiceV2Service', () => {
       expect(body.dateFrom).toBe('2024-01-01');
       expect(body.invoiceTypes).toEqual(['Sales', 'Purchase']);
     });
+
+    it('preserves requested export compression type', async () => {
+      mockHttpClient.mockResponse({ referenceNumber: 'exp-ref' });
+
+      const service = new InvoiceV2Service(mockHttpClient as any, 'test');
+
+      await service.exportInvoices('token', {
+        encryption: {
+          encryptedSymmetricKey: 'key',
+          initializationVector: 'iv'
+        },
+        filters: {
+          subjectType: 'Subject1',
+          dateRange: {
+            dateType: 'Issue',
+            from: '2024-01-01'
+          }
+        },
+        compressionType: 'TarGz'
+      });
+
+      const request = mockHttpClient.getLastRequest();
+      const body = JSON.parse(request?.body!);
+      expect(body.compressionType).toBe('TarGz');
+    });
   });
 
   describe('getInvoiceExportStatus', () => {
@@ -258,4 +283,3 @@ describe('InvoiceV2Service', () => {
     });
   });
 });
-

--- a/tests/utils/http-auth-manager.test.ts
+++ b/tests/utils/http-auth-manager.test.ts
@@ -196,4 +196,30 @@ describe('HttpClient X-System-Warning integration', () => {
       status: 200
     });
   });
+
+  it('does not let onSystemWarning errors change a successful response', async () => {
+    const onSystemWarning = vi.fn(() => {
+      throw new Error('observer failed');
+    });
+    const run = vi.fn(async () => ({
+      status: 200,
+      statusText: 'OK',
+      headers: {
+        'X-System-Warning': '[WARN_1]: First warning'
+      },
+      data: { ok: true }
+    }));
+    const client = new TestHttpClient(run, { onSystemWarning });
+
+    await expect(client.request({
+      method: 'GET',
+      url: 'https://example.com/test'
+    })).resolves.toMatchObject({
+      status: 200,
+      data: { ok: true }
+    });
+
+    expect(onSystemWarning).toHaveBeenCalledTimes(1);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
 });

--- a/tests/utils/http-auth-manager.test.ts
+++ b/tests/utils/http-auth-manager.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { HttpClient, type HttpRequestOptions, type HttpResponse } from '../../src/utils/http.js';
 import { AuthenticationError } from '../../src/types/common.js';
 import type { AuthManager } from '../../src/api2/auth-manager.js';
+import type { HttpClientOptions } from '../../src/types/config.js';
 
 function createStubAuthManager(overrides: Partial<AuthManager> = {}): AuthManager {
   let accessToken = 'managed-access-token';
@@ -24,9 +25,9 @@ function createStubAuthManager(overrides: Partial<AuthManager> = {}): AuthManage
 class TestHttpClient extends HttpClient {
   constructor(
     private readonly run: (options: HttpRequestOptions) => Promise<HttpResponse<unknown>>,
-    authManager?: AuthManager
+    options: HttpClientOptions = {}
   ) {
-    super({ authManager, maxRetries: 3 });
+    super({ maxRetries: 3, ...options });
   }
 
   protected override async executeRequest<T>(requestOptions: HttpRequestOptions, _url: URL): Promise<HttpResponse<T>> {
@@ -43,7 +44,7 @@ describe('HttpClient AuthManager integration', () => {
       headers: {},
       data: { ok: true, authorization: options.headers?.Authorization }
     }));
-    const client = new TestHttpClient(run, authManager);
+    const client = new TestHttpClient(run, { authManager });
 
     const response = await client.request({
       method: 'GET',
@@ -66,7 +67,7 @@ describe('HttpClient AuthManager integration', () => {
         headers: {},
         data: { ok: true }
       });
-    const client = new TestHttpClient(run, authManager);
+    const client = new TestHttpClient(run, { authManager });
 
     const response = await client.request({
       method: 'GET',
@@ -86,7 +87,7 @@ describe('HttpClient AuthManager integration', () => {
     const onUnauthorized = vi.fn(async () => 'refreshed-access-token');
     const authManager = createStubAuthManager({ onUnauthorized });
     const run = vi.fn().mockRejectedValueOnce(new AuthenticationError('Unauthorized', { statusCode: 401 }));
-    const client = new TestHttpClient(run, authManager);
+    const client = new TestHttpClient(run, { authManager });
 
     await expect(client.request({
       method: 'POST',
@@ -99,5 +100,100 @@ describe('HttpClient AuthManager integration', () => {
 
     expect(onUnauthorized).not.toHaveBeenCalled();
     expect(run).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('HttpClient X-System-Warning integration', () => {
+  it('calls onSystemWarning when a successful response contains X-System-Warning', async () => {
+    const onSystemWarning = vi.fn();
+    const run = vi.fn(async () => ({
+      status: 200,
+      statusText: 'OK',
+      headers: {
+        'X-System-Warning': '[WARN_1]: First warning'
+      },
+      data: { ok: true }
+    }));
+    const client = new TestHttpClient(run, { onSystemWarning });
+
+    await client.request({
+      method: 'GET',
+      url: 'https://example.com/test?value=1'
+    });
+
+    expect(onSystemWarning).toHaveBeenCalledTimes(1);
+    expect(onSystemWarning).toHaveBeenCalledWith({
+      code: 'WARN_1',
+      message: 'First warning',
+      raw: '[WARN_1]: First warning',
+      method: 'GET',
+      url: 'https://example.com/test?value=1',
+      status: 200
+    });
+  });
+
+  it('parses multiple system warnings from a case-insensitive header', async () => {
+    const onSystemWarning = vi.fn();
+    const run = vi.fn(async () => ({
+      status: 202,
+      statusText: 'Accepted',
+      headers: {
+        'x-system-warning': '[WARN_1]: First warning | [WARN_2]: Second warning'
+      },
+      data: null
+    }));
+    const client = new TestHttpClient(run, { onSystemWarning });
+
+    await client.request({
+      method: 'POST',
+      url: 'https://example.com/process'
+    });
+
+    expect(onSystemWarning).toHaveBeenCalledTimes(2);
+    expect(onSystemWarning.mock.calls.map(([warning]) => warning)).toEqual([
+      {
+        code: 'WARN_1',
+        message: 'First warning',
+        raw: '[WARN_1]: First warning | [WARN_2]: Second warning',
+        method: 'POST',
+        url: 'https://example.com/process',
+        status: 202
+      },
+      {
+        code: 'WARN_2',
+        message: 'Second warning',
+        raw: '[WARN_1]: First warning | [WARN_2]: Second warning',
+        method: 'POST',
+        url: 'https://example.com/process',
+        status: 202
+      }
+    ]);
+  });
+
+  it('passes unparsed system warning headers as UNKNOWN', async () => {
+    const onSystemWarning = vi.fn();
+    const run = vi.fn(async () => ({
+      status: 200,
+      statusText: 'OK',
+      headers: {
+        'X-System-Warning': 'unexpected warning format'
+      },
+      data: { ok: true }
+    }));
+    const client = new TestHttpClient(run, { onSystemWarning });
+
+    await client.request({
+      method: 'GET',
+      url: 'https://example.com/test'
+    });
+
+    expect(onSystemWarning).toHaveBeenCalledWith({
+      code: 'UNKNOWN',
+      message: 'unexpected warning format',
+      raw: 'unexpected warning format',
+      method: 'GET',
+      url: 'https://example.com/test',
+      status: 200
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add a high-level `client.batch` workflow for TarGz batch preparation, encrypted part metadata, upload, polling, pagination, and invoiceHash-based result correlation
- keep the existing raw-buffer batch session helper as the low-level/advanced path
- add invoice export `compressionType` typing and KSeF `X-System-Warning` callback support

## Verification
- `pnpm run build`
- `pnpm run test:unit`
- `pnpm vitest run tests/services/invoice.test.ts`
- `pnpm vitest run tests/utils/http-auth-manager.test.ts tests/utils/http.test.ts`
- staged batch patch was also build/test verified in a temporary clean worktree before commit

## Not included
- local tooling/OpenAPI snapshot changes remain uncommitted and are intended for a later commit/PR
